### PR TITLE
Initial Programmatic Arm Control

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import edu.wpi.first.gradlerio.deploy.roborio.RoboRIO
 
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2023.2.1" 
+    id "edu.wpi.first.GradleRIO" version "2023.3.2"
     id 'checkstyle'
     id 'jacoco'
     id 'org.hidetake.ssh' version "2.9.0"

--- a/src/main/deploy/log4j.xml
+++ b/src/main/deploy/log4j.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd" >
 <log4j:configuration>
+
+   <appender name="consoleAppender"
+             class="org.apache.log4j.ConsoleAppender">
+      <param name="Threshold" value="INFO" />
+      <layout class="org.apache.log4j.PatternLayout">
+         <param name="ConversionPattern" value="%5p | %d | %L | %-40c{1} | %m%n" />
+      </layout>
+   </appender>
    
    <appender name="stationAppender"
       class="xbot.common.logging.DriverStationAppender">
@@ -32,6 +40,7 @@
 
 <root>
     <priority value="INFO"></priority>
+    <appender-ref ref="consoleAppender"/>
     <appender-ref ref="asyncAppender"/>
     <appender-ref ref="stationAppender"/>
 </root>

--- a/src/main/java/competition/Robot.java
+++ b/src/main/java/competition/Robot.java
@@ -24,8 +24,8 @@ public class Robot extends BaseRobot {
         if (BaseRobot.isReal()) {
             // TODO: Figure out some elegant way to detect 2022 vs 2023 chassis and return the appropriate component.
             // until then, you'll have to manually change this line to return the correct component.
-            return DaggerPracticeComponent.create();
-            //return DaggerRobotComponent.create();
+            //return DaggerPracticeComponent.create();
+            return DaggerRobotComponent.create();
 
         } else {
             return DaggerSimulationComponent.create();

--- a/src/main/java/competition/electrical_contract/CompetitionContract.java
+++ b/src/main/java/competition/electrical_contract/CompetitionContract.java
@@ -120,7 +120,7 @@ public class CompetitionContract extends ElectricalContract {
 
     @Override
     public DeviceInfo getUpperArmRightMotor() {
-        return new DeviceInfo(24,false);
+        return new DeviceInfo(24,true);
     }
 
     public boolean isLowerArmReady() { return true;}
@@ -139,12 +139,12 @@ public class CompetitionContract extends ElectricalContract {
 
     @Override
     public DeviceInfo getLowerArmEncoder() {
-        return new DeviceInfo(0, false);
+        return new DeviceInfo(0, true);
     }
 
     @Override
     public DeviceInfo getUpperArmEncoder() {
-        return new DeviceInfo(1, false);
+        return new DeviceInfo(1, true);
     }
 
     public DeviceInfo getClawSolenoid() {return new DeviceInfo(5, false);}

--- a/src/main/java/competition/electrical_contract/CompetitionContract.java
+++ b/src/main/java/competition/electrical_contract/CompetitionContract.java
@@ -115,7 +115,7 @@ public class CompetitionContract extends ElectricalContract {
     }
 
     public DeviceInfo getUpperArmLeftMotor(){
-        return new DeviceInfo(35,false);
+        return new DeviceInfo(35,true);
     }
 
     @Override
@@ -129,12 +129,12 @@ public class CompetitionContract extends ElectricalContract {
 
     @Override
     public boolean isLowerArmEncoderReady() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isUpperArmEncoderReady() {
-        return false;
+        return true;
     }
 
     @Override

--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -14,9 +14,12 @@ import competition.subsystems.drive.commands.SwerveToPointCommand;
 import competition.subsystems.drive.commands.TurnLeft90DegreesCommand;
 import competition.subsystems.pose.PoseSubsystem;
 import competition.subsystems.vision.VisionSubsystem;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.StartEndCommand;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 import xbot.common.command.NamedInstantCommand;
 import xbot.common.controls.sensors.XXboxController.XboxButton;
 import xbot.common.math.XYPair;
@@ -36,17 +39,18 @@ import javax.inject.Singleton;
 public class OperatorCommandMap {
 
     @Inject
-    public OperatorCommandMap() {}
-    
+    public OperatorCommandMap() {
+    }
+
     @Inject
     public void setupDriveCommands(OperatorInterface oi,
-            SetRobotHeadingCommand resetHeading,
-            DriveSubsystem drive,
-            PoseSubsystem pose,
-            DebuggingSwerveWithJoysticksCommand debugSwerve,
-            GoToNextActiveSwerveModuleCommand nextModule,
-            SwerveDriveWithJoysticksCommand regularSwerve,
-            VisionSubsystem vision) {
+                                   SetRobotHeadingCommand resetHeading,
+                                   DriveSubsystem drive,
+                                   PoseSubsystem pose,
+                                   DebuggingSwerveWithJoysticksCommand debugSwerve,
+                                   GoToNextActiveSwerveModuleCommand nextModule,
+                                   SwerveDriveWithJoysticksCommand regularSwerve,
+                                   VisionSubsystem vision) {
         resetHeading.setHeadingToApply(0);
 
         NamedInstantCommand resetPosition = new NamedInstantCommand("Reset Position",
@@ -85,11 +89,11 @@ public class OperatorCommandMap {
 
     @Inject
     public void setupMobilityCommands(OperatorInterface oi,
-            TurnLeft90DegreesCommand turnleft90,
-            SwerveToPointCommand swerveToPoint,
+                                      TurnLeft90DegreesCommand turnleft90,
+                                      SwerveToPointCommand swerveToPoint,
 
-            DriveSubsystem drive,
-            PropertyFactory pf) {
+                                      DriveSubsystem drive,
+                                      PropertyFactory pf) {
 
         pf.setPrefix("OperatorCommandMap/");
         DoubleProperty xTarget = pf.createEphemeralProperty("OI/SwerveToPointTargetX", 0);
@@ -128,31 +132,79 @@ public class OperatorCommandMap {
         setBlueBottomScoring.includeOnSmartDashboard("AutoPrograms/SetBlueButtomScoring");
     }
 
+    @Inject
     public void setupArmCommands(
             OperatorInterface oi,
             UnifiedArmSubsystem arm,
             SetArmsToPositionCommand setHigh,
             SetArmsToPositionCommand setMid,
             SetArmsToPositionCommand setLow,
-            SetArmsToPositionCommand setRetract){
+            SetArmsToPositionCommand setRetract) {
         setLow.setTargetPosition(KeyArmPosition.lowerGoal);
         setMid.setTargetPosition(KeyArmPosition.midGoal);
         setHigh.setTargetPosition(KeyArmPosition.highGoal);
         setRetract.setTargetPosition(KeyArmPosition.fullyRetracted);
-
+        /*
         oi.operatorGamepad.getifAvailable(XboxButton.B).onTrue(setLow);
         oi.operatorGamepad.getifAvailable(XboxButton.Y).onTrue(setMid);
         oi.operatorGamepad.getifAvailable(XboxButton.A).onTrue(setHigh);
         oi.operatorGamepad.getifAvailable(XboxButton.X).onTrue(setRetract);
+        */
+        InstantCommand setNeg90 = new InstantCommand(
+                () -> {
+                    Logger log = LogManager.getLogger(OperatorCommandMap.class);
+                    log.info("Setting neg 90");
+                    arm.setTargetValue(new XYPair(-90, -90));
+                });
+
+        InstantCommand setNeg45 = new InstantCommand(
+                () -> {
+                    Logger log = LogManager.getLogger(OperatorCommandMap.class);
+                    log.info("Setting neg 45");
+                    arm.setTargetValue(new XYPair(-90, -45));
+                });
+
+        InstantCommand setNeg135 = new InstantCommand(
+                () -> {
+                    Logger log = LogManager.getLogger(OperatorCommandMap.class);
+                    log.info("Setting neg 135");
+                    arm.setTargetValue(new XYPair(-90, -135));
+                });
+
+        oi.operatorGamepad.getifAvailable(XboxButton.A).onTrue(setNeg90);
+        oi.operatorGamepad.getifAvailable(XboxButton.B).onTrue(setNeg45);
+        oi.operatorGamepad.getifAvailable(XboxButton.X).onTrue(setNeg135);
+
 
         //turn on soft limits
-        InstantCommand setSoftLimits = new InstantCommand(()-> arm.setSoftLimits(true));
+        InstantCommand setSoftLimits = new InstantCommand(
+                () -> {
+                    Logger log = LogManager.getLogger(OperatorCommandMap.class);
+                    log.info("Activating soft limits");
+                    arm.setSoftLimits(true);
+                });
         oi.operatorGamepad.getifAvailable(XboxButton.LeftBumper).onTrue(setSoftLimits);
 
 
         //turn off soft limits
-        InstantCommand disableSoftLimits = new InstantCommand(()-> arm.setSoftLimits(false));
+        InstantCommand disableSoftLimits = new InstantCommand(
+                () -> {
+                    Logger log = LogManager.getLogger(OperatorCommandMap.class);
+                    log.info("Disabling soft limits");
+                    arm.setSoftLimits(false);
+                });
+
         oi.operatorGamepad.getifAvailable(XboxButton.RightBumper).onTrue(disableSoftLimits);
+
+        // Calibrate upper arm against the absolute encoder
+        InstantCommand calibrateUpperArm = new InstantCommand(
+                () -> {
+                    Logger log = LogManager.getLogger(OperatorCommandMap.class);
+                    log.info("CalibratingArms");
+                    arm.calibrateAgainstAbsoluteEncoders();
+                }
+        );
+        oi.operatorGamepad.getifAvailable(XboxButton.Back).onTrue(calibrateUpperArm);
 
 
     }

--- a/src/main/java/competition/operator_interface/OperatorInterface.java
+++ b/src/main/java/competition/operator_interface/OperatorInterface.java
@@ -31,7 +31,7 @@ public class OperatorInterface {
 
         operatorGamepad = controllerFactory.create(1);
         operatorGamepad.setLeftInversion(false, true);
-        operatorGamepad.setRightInversion(true, true);
+        operatorGamepad.setRightInversion(false, true);
 
         pf.setPrefix("OperatorInterface");
         driverDeadband = pf.createPersistentProperty("Driver Deadband", 0.12);

--- a/src/main/java/competition/subsystems/arm/ArmSegment.java
+++ b/src/main/java/competition/subsystems/arm/ArmSegment.java
@@ -132,14 +132,6 @@ public abstract class ArmSegment {
         getLeaderMotor().setSoftLimit(CANSparkMax.SoftLimitDirection.kReverse,(float)lower);
     }
 
-    public double getUpperLimitInDegrees() {
-        return upperLimitInDegrees.get();
-    }
-
-    public double getLowerLimitInDegrees() {
-        return lowerLimitInDegrees.get();
-    }
-
     public void setArmToAngle(Rotation2d angle) {
 
         // Coerce angle to a safe angle

--- a/src/main/java/competition/subsystems/arm/ArmSegment.java
+++ b/src/main/java/competition/subsystems/arm/ArmSegment.java
@@ -18,12 +18,17 @@ public abstract class ArmSegment {
     private double motorEncoderOffsetInDegrees;
     private double absoluteEncoderOffsetInDegrees;
 
+    private final DoubleProperty absoluteEncoderPositionProp;
+    private final DoubleProperty neoPositionProp;
+
     public ArmSegment(String prefix, PropertyFactory propFactory) {
         propFactory.setPrefix(prefix);
         upperLimitInDegrees = propFactory.createPersistentProperty("upperLimitInDegrees", 0);
         lowerLimitInDegrees = propFactory.createPersistentProperty("lowerLimitInDegrees", 0);
         degreesPerMotorRotationProp = propFactory.createPersistentProperty("degreesPerMotorRotation", 360);
         useAbsoluteEncoderProp = propFactory.createPersistentProperty("useAbsoluteEncoder", false);
+        absoluteEncoderPositionProp = propFactory.createEphemeralProperty("AbsoluteEncoderPosition", 0.0);
+        neoPositionProp = propFactory.createEphemeralProperty("NeoPosition", 0.0);
     }
 
     protected abstract XCANSparkMax getLeaderMotor();
@@ -113,5 +118,10 @@ public abstract class ArmSegment {
             double goalPosition = deltaInMotorRotations + getLeaderMotor().getPosition();;
             getLeaderMotor().setReference(goalPosition, CANSparkMax.ControlType.kPosition);
         }
+    }
+
+    public void periodic() {
+        absoluteEncoderPositionProp.set(getAbsoluteEncoder().getWrappedPosition().getDegrees());
+        neoPositionProp.set(getLeaderMotor().getPosition());
     }
 }

--- a/src/main/java/competition/subsystems/arm/ArmSegment.java
+++ b/src/main/java/competition/subsystems/arm/ArmSegment.java
@@ -6,6 +6,7 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import xbot.common.controls.actuators.XCANSparkMax;
 import xbot.common.controls.sensors.XDutyCycleEncoder;
+import xbot.common.math.ContiguousDouble;
 import xbot.common.math.MathUtils;
 import xbot.common.math.WrappedRotation2d;
 import xbot.common.properties.BooleanProperty;
@@ -70,8 +71,10 @@ public abstract class ArmSegment {
 
     public double getArmPositionFromAbsoluteEncoderInDegrees() {
         if (isAbsoluteEncoderReady()) {
-            return getAbsoluteEncoder().getContiguousPosition(lowerDegreeReference, upperDegreeReference).getValue()
-                    - getAbsoluteEncoderOffsetInDegrees();
+            return ContiguousDouble.reboundValue(
+                    getAbsoluteEncoder().getAbsoluteDegrees()- getAbsoluteEncoderOffsetInDegrees(),
+                    lowerDegreeReference,
+                    upperDegreeReference);
         }
         return 0;
     }

--- a/src/main/java/competition/subsystems/arm/LowerArmSegment.java
+++ b/src/main/java/competition/subsystems/arm/LowerArmSegment.java
@@ -4,7 +4,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import competition.electrical_contract.ElectricalContract;
-import edu.wpi.first.networktables.DoubleEntry;
 import xbot.common.controls.actuators.XCANSparkMax;
 import xbot.common.controls.actuators.XCANSparkMax.XCANSparkMaxFactory;
 import xbot.common.controls.sensors.XDutyCycleEncoder;
@@ -22,15 +21,17 @@ public class LowerArmSegment extends ArmSegment {
     public  DoubleProperty extendLimit;
     public  DoubleProperty retractLimit;
     private final DoubleProperty degreesPerMotorRotationProp;
+    private final DoubleProperty absoluteEncoderOffsetInDegreesProp;
 
     @Inject
     public LowerArmSegment(XCANSparkMaxFactory sparkMaxFactory, XDutyCycleEncoder.XDutyCycleEncoderFactory dutyCycleEncoderFactory,
                            ElectricalContract eContract, PropertyFactory propFactory){
-        super("UnifiedArmSubsystem/LowerArm", propFactory);
+        super("UnifiedArmSubsystem/LowerArm", propFactory, 270, -90);
         String prefix = "UnifiedArmSubsystem/LowerArm";
 
         propFactory.setPrefix(prefix);
         degreesPerMotorRotationProp = propFactory.createPersistentProperty("degreesPerMotorRotation", 4.22);
+        absoluteEncoderOffsetInDegreesProp = propFactory.createPersistentProperty("AbsoluteEncoderOffsetInDegrees", 0.0);
 
         this.contract = eContract;
         if(contract.isLowerArmReady()){
@@ -50,6 +51,11 @@ public class LowerArmSegment extends ArmSegment {
     @Override
     protected double getDegreesPerMotorRotation() {
         return degreesPerMotorRotationProp.get();
+    }
+
+    @Override
+    protected double getAbsoluteEncoderOffsetInDegrees() {
+        return absoluteEncoderOffsetInDegreesProp.get();
     }
 
     @Override

--- a/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
+++ b/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
@@ -182,8 +182,13 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
         return new Pair<>(lowerArmRiskState, upperArmRiskState);
     }
    
-    public void setSoftLimits(boolean on){
+    public void setSoftLimits(boolean on) {
         lowerArm.setSoftLimit(on);
         upperArm.setSoftLimit(on);
+    }
+
+    @Override
+    public void periodic() {
+        upperArm.periodic();
     }
 }

--- a/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
+++ b/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
@@ -59,10 +59,7 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
         calibratedProp = pf.createEphemeralProperty("Calibrated", false);
         upperArmTarget = pf.createEphemeralProperty("UpperArmTarget", 0.0);
         lowerArmTarget = pf.createEphemeralProperty("LowerArmTarget", 0.0);
-        targetPosition = new XYPair(
-                lowerArm.getArmPositionFromAbsoluteEncoderInDegrees(),
-                upperArm.getArmPositionFromAbsoluteEncoderInDegrees()
-        );
+        targetPosition = getCurrentValue();
     }
 
     public XYPair getKeyArmPosition(KeyArmPosition keyArmPosition){

--- a/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
+++ b/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
@@ -5,6 +5,9 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import xbot.common.command.BaseSetpointSubsystem;
 import xbot.common.logic.HumanVsMachineDecider;
 import xbot.common.math.XYPair;
+import xbot.common.properties.BooleanProperty;
+import xbot.common.properties.DoubleProperty;
+import xbot.common.properties.PropertyFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -17,8 +20,8 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
 
     private XYPair targetPosition;
     public final ArmPositionSolver solver;
-
-    private HumanVsMachineDecider humanVsMachineDecider;
+    private final DoubleProperty lowerArmTarget;
+    private final DoubleProperty upperArmTarget;
 
     public enum KeyArmPosition {
         lowerGoal,
@@ -34,10 +37,13 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
 
     double testRangeRadians = 0.17453292519943295; // 10 degrees
 
+    protected final BooleanProperty calibratedProp;
+
     @Inject
     public UnifiedArmSubsystem(
             LowerArmSegment lowerArm,
-            UpperArmSegment upperArm) {
+            UpperArmSegment upperArm,
+            PropertyFactory pf) {
         this.lowerArm = lowerArm;
         this.upperArm = upperArm;
         ArmPositionSolverConfiguration armConfig = new ArmPositionSolverConfiguration(
@@ -49,6 +55,14 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
             Rotation2d.fromDegrees(-5.0)
         );
         solver = new ArmPositionSolver(armConfig);
+        pf.setPrefix(this);
+        calibratedProp = pf.createEphemeralProperty("Calibrated", false);
+        upperArmTarget = pf.createEphemeralProperty("UpperArmTarget", 0.0);
+        lowerArmTarget = pf.createEphemeralProperty("LowerArmTarget", 0.0);
+        targetPosition = new XYPair(
+                lowerArm.getArmPositionFromAbsoluteEncoderInDegrees(),
+                upperArm.getArmPositionFromAbsoluteEncoderInDegrees()
+        );
     }
 
     public XYPair getKeyArmPosition(KeyArmPosition keyArmPosition){
@@ -80,9 +94,18 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
 
     @Override
     public XYPair getCurrentValue() {
+
+        return new XYPair(
+                lowerArm.getArmPositionFromAbsoluteEncoderInDegrees(),
+                upperArm.getArmPositionFromAbsoluteEncoderInDegrees()
+        );
+        // Eventually do the smart thing. For now, just do angles.
+        /*
         return solver.getPositionFromRadians(
             lowerArm.getArmPositionInRadians(),
             upperArm.getArmPositionInRadians());
+
+         */
     }
 
     @Override
@@ -112,12 +135,17 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
 
     @Override
     public boolean isCalibrated() {
-        return false;
+        return calibratedProp.get();
     }
 
     public void calibrateAt(double lowerArmAngleInDegrees, double upperArmAngleInDegrees) {
         lowerArm.calibrateThisPositionAs(lowerArmAngleInDegrees);
         upperArm.calibrateThisPositionAs(upperArmAngleInDegrees);
+    }
+
+    public void calibrateAgainstAbsoluteEncoders() {
+        lowerArm.calibrateThisPositionAs(lowerArm.getArmPositionFromAbsoluteEncoderInDegrees());
+        upperArm.calibrateThisPositionAs(upperArm.getArmPositionFromAbsoluteEncoderInDegrees());
     }
 
     /**
@@ -189,6 +217,9 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
 
     @Override
     public void periodic() {
+        lowerArmTarget.set(getTargetValue().x);
+        upperArmTarget.set(getTargetValue().y);
+
         upperArm.periodic();
         lowerArm.periodic();
     }

--- a/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
+++ b/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
@@ -190,5 +190,6 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
     @Override
     public void periodic() {
         upperArm.periodic();
+        lowerArm.periodic();
     }
 }

--- a/src/main/java/competition/subsystems/arm/UpperArmSegment.java
+++ b/src/main/java/competition/subsystems/arm/UpperArmSegment.java
@@ -67,9 +67,4 @@ public class UpperArmSegment extends ArmSegment {
     public boolean isAbsoluteEncoderReady() {
         return contract.isLowerArmEncoderReady();
     }
-
-    public void periodic() {
-        absoluteEncoderProp.set(absoluteEncoder.getWrappedPosition().getDegrees());
-        neoPositionProp.set(rightMotor.getPosition());
-    }
 }

--- a/src/main/java/competition/subsystems/arm/UpperArmSegment.java
+++ b/src/main/java/competition/subsystems/arm/UpperArmSegment.java
@@ -21,11 +21,15 @@ public class UpperArmSegment extends ArmSegment {
     public  DoubleProperty extendLimit;
     public  DoubleProperty retractLimit;
 
+    public final DoubleProperty absoluteEncoderProp;
+    public final DoubleProperty neoPositionProp;
+
     @Inject
     public UpperArmSegment(XCANSparkMaxFactory sparkMaxFactory, XDutyCycleEncoder.XDutyCycleEncoderFactory dutyCycleEncoderFactory,
                            ElectricalContract eContract, PropertyFactory propFactory){
         super("UnifiedArmSubsystem/UpperArm", propFactory);
         String prefix = "UnifiedArmSubsystem/UpperArm";
+        propFactory.setPrefix(prefix);
         this.contract = eContract;
         if(contract.isLowerArmReady()){
             this.leftMotor = sparkMaxFactory.create(eContract.getUpperArmLeftMotor(), prefix,"LeftMotor");
@@ -33,11 +37,14 @@ public class UpperArmSegment extends ArmSegment {
 
             leftMotor.follow(rightMotor, contract.getUpperArmLeftMotor().inverted);
         }
-        if (contract.isLowerArmEncoderReady()) {
+        if (contract.isUpperArmEncoderReady()) {
             this.absoluteEncoder = dutyCycleEncoderFactory.create(contract.getUpperArmEncoder());
         }
 
         setSoftLimit(false);
+
+        absoluteEncoderProp = propFactory.createEphemeralProperty("AbsoluteEncoder", 0.0);
+        neoPositionProp = propFactory.createEphemeralProperty("NeoPosition", 0.0);
     }
 
 
@@ -59,5 +66,10 @@ public class UpperArmSegment extends ArmSegment {
     @Override
     public boolean isAbsoluteEncoderReady() {
         return contract.isLowerArmEncoderReady();
+    }
+
+    public void periodic() {
+        absoluteEncoderProp.set(absoluteEncoder.getWrappedPosition().getDegrees());
+        neoPositionProp.set(rightMotor.getPosition());
     }
 }

--- a/src/main/java/competition/subsystems/arm/UpperArmSegment.java
+++ b/src/main/java/competition/subsystems/arm/UpperArmSegment.java
@@ -3,6 +3,7 @@ package competition.subsystems.arm;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import com.revrobotics.CANSparkMax;
 import competition.electrical_contract.ElectricalContract;
 import xbot.common.controls.actuators.XCANSparkMax;
 import xbot.common.controls.actuators.XCANSparkMax.XCANSparkMaxFactory;
@@ -21,17 +22,16 @@ public class UpperArmSegment extends ArmSegment {
     public  DoubleProperty extendLimit;
     public  DoubleProperty retractLimit;
     private final DoubleProperty degreesPerMotorRotationProp;
-
-    public final DoubleProperty absoluteEncoderProp;
-    public final DoubleProperty neoPositionProp;
+    private final DoubleProperty absoluteEncoderOffsetInDegreesProp;
 
     @Inject
     public UpperArmSegment(XCANSparkMaxFactory sparkMaxFactory, XDutyCycleEncoder.XDutyCycleEncoderFactory dutyCycleEncoderFactory,
                            ElectricalContract eContract, PropertyFactory propFactory){
-        super("UnifiedArmSubsystem/UpperArm", propFactory);
+        super("UnifiedArmSubsystem/UpperArm", propFactory, 90, -270);
         String prefix = "UnifiedArmSubsystem/UpperArm";
         propFactory.setPrefix(prefix);
         degreesPerMotorRotationProp = propFactory.createPersistentProperty("degreesPerMotorRotation",1.26);
+        absoluteEncoderOffsetInDegreesProp = propFactory.createPersistentProperty("AbsoluteEncoderOffsetInDegrees", 0.0);
 
         this.contract = eContract;
         if(contract.isLowerArmReady()){
@@ -39,21 +39,28 @@ public class UpperArmSegment extends ArmSegment {
             this.rightMotor = sparkMaxFactory.create(eContract.getUpperArmRightMotor(), prefix,"RightMotor");
 
             leftMotor.follow(rightMotor, contract.getUpperArmLeftMotor().inverted);
+
+            rightMotor.setIdleMode(CANSparkMax.IdleMode.kBrake);
+            leftMotor.setIdleMode(CANSparkMax.IdleMode.kBrake);
+
+            rightMotor.setOpenLoopRampRate(0.05);
+            rightMotor.setClosedLoopRampRate(0.05);
         }
         if (contract.isUpperArmEncoderReady()) {
             this.absoluteEncoder = dutyCycleEncoderFactory.create(contract.getUpperArmEncoder());
         }
 
         setSoftLimit(false);
-
-        absoluteEncoderProp = propFactory.createEphemeralProperty("AbsoluteEncoder", 0.0);
-        neoPositionProp = propFactory.createEphemeralProperty("NeoPosition", 0.0);
     }
-
 
     @Override
     protected double getDegreesPerMotorRotation() {
         return degreesPerMotorRotationProp.get();
+    }
+
+    @Override
+    protected double getAbsoluteEncoderOffsetInDegrees() {
+        return absoluteEncoderOffsetInDegreesProp.get();
     }
 
     @Override
@@ -74,5 +81,11 @@ public class UpperArmSegment extends ArmSegment {
     @Override
     public boolean isAbsoluteEncoderReady() {
         return contract.isLowerArmEncoderReady();
+    }
+
+    @Override
+    public void periodic() {
+        super.periodic();
+        rightMotor.periodic();
     }
 }

--- a/src/main/java/competition/subsystems/arm/commands/UnifiedArmMaintainer.java
+++ b/src/main/java/competition/subsystems/arm/commands/UnifiedArmMaintainer.java
@@ -4,6 +4,7 @@ import competition.operator_interface.OperatorInterface;
 import competition.subsystems.arm.UnifiedArmSubsystem;
 import competition.subsystems.drive.swerve.SwerveSteeringSubsystem;
 import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.geometry.Rotation2d;
 import xbot.common.command.BaseMaintainerCommand;
 import xbot.common.logic.HumanVsMachineDecider;
 import xbot.common.math.MathUtils;
@@ -41,9 +42,16 @@ public class UnifiedArmMaintainer extends BaseMaintainerCommand<XYPair> {
     protected void calibratedMachineControlAction() {
         XYPair target = unifiedArm.getTargetValue();
         // Find out what angles the arms need to be at in order to achieve the goal.
+
+
+        // Eventually do this. For now just do direct angle setting.
+        /*
         var desiredArmAngles = unifiedArm.solver.solveArmJointPositions(target.x, target.y);
         // Ask the subsystem to move the arms to those angles.
         unifiedArm.setArmsToAngles(desiredArmAngles.getLowerJointRotation(), desiredArmAngles.getUpperJointRotation());
+
+         */
+        unifiedArm.setArmsToAngles(Rotation2d.fromDegrees(target.x), Rotation2d.fromDegrees(target.y));
     }
 
     @Override

--- a/src/main/java/competition/subsystems/arm/commands/UnifiedArmMaintainer.java
+++ b/src/main/java/competition/subsystems/arm/commands/UnifiedArmMaintainer.java
@@ -20,6 +20,7 @@ public class UnifiedArmMaintainer extends BaseMaintainerCommand<XYPair> {
     public UnifiedArmMaintainer(
             UnifiedArmSubsystem subsystemToMaintain,
             PropertyFactory pf,
+            OperatorInterface oi,
             HumanVsMachineDecider.HumanVsMachineDeciderFactory hvmFactory) {
         super(subsystemToMaintain, pf, hvmFactory, 0.001, 0.001);
         this.unifiedArm = subsystemToMaintain;

--- a/src/main/java/competition/subsystems/drive/commands/SwerveSteeringMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/SwerveSteeringMaintainerCommand.java
@@ -37,7 +37,7 @@ public class SwerveSteeringMaintainerCommand extends BaseMaintainerCommand<Doubl
             this.subsystem.setPower(this.subsystem.calculatePower());
         }
 
-        if (enableAutoCalibrate.get() && isMaintainerAtGoal()) {
+        if (enableAutoCalibrate.get() && isMaintainerAtGoal() && Math.abs(subsystem.getVelocity()) < 0.001) {
             this.subsystem.calibrateMotorControllerPositionFromCanCoder();
         }
     }

--- a/src/main/java/competition/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/competition/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -185,6 +185,10 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
         this.calibrated = true;
     }
 
+    public double getVelocity() {
+        return this.motorController.getVelocity();
+    }
+
     /**
      * Reset the SparkMax encoder position based on the CanCoder measurement.
      * This should only be called when the mechanism is stationary.
@@ -196,7 +200,8 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
 
             if (isMotorControllerDriftTooHigh(currentCanCoderPosition, currentSparkMaxPosition, this.maxMotorEncoderDrift.get())) {
                 if (Math.abs(this.motorController.getVelocity()) > 0) {
-                    log.error("This should not be called when the motor is moving!");
+                    // TODO: this is being called constantly. Seems like a bug.
+                    //log.info("This was called when the motor is moving. No action will be taken.");
                 } else {
                     log.warn("Motor controller encoder drift is too high, recalibrating!");
 

--- a/src/main/java/competition/subsystems/vision/VisionSubsystem.java
+++ b/src/main/java/competition/subsystems/vision/VisionSubsystem.java
@@ -145,7 +145,8 @@ public class VisionSubsystem extends BaseSubsystem {
     public Optional<EstimatedRobotPose> getPhotonVisionEstimatedPose(Pose2d previousEstimatedRobotPose) {
         if (visionWorking) {
             photonPoseEstimator.setReferencePose(previousEstimatedRobotPose);
-            return photonPoseEstimator.update();
+            //return photonPoseEstimator.update();
+            return Optional.empty();
         } else {
             return Optional.empty();
         }

--- a/src/test/java/competition/subsystems/arm/UnifiedArmTest.java
+++ b/src/test/java/competition/subsystems/arm/UnifiedArmTest.java
@@ -1,6 +1,7 @@
 package competition.subsystems.arm;
 
 import competition.BaseCompetitionTest;
+import org.junit.Ignore;
 import org.junit.Test;
 import xbot.common.math.XYPair;
 
@@ -31,7 +32,7 @@ public class UnifiedArmTest extends BaseCompetitionTest {
         assertEquals(0.75, target.y, 0.001);
     }
 
-    @Test
+    @Test @Ignore // Revisit once we set XZ positions rather than raw angles.
     public void testTypicalCalibrate() {
         arms.typicalCalibrate();
         var effectorPosition = arms.getCurrentValue();
@@ -39,7 +40,7 @@ public class UnifiedArmTest extends BaseCompetitionTest {
         assertEquals(6, effectorPosition.y, 0.001); // Remember, this is "Z"
     }
 
-    @Test
+    @Test @Ignore // Revisit once we set XZ positions rather than raw angles.
     public void testCalibrateAt() {
         arms.calibrateAt(90, 0);
         var effectorPosition = arms.getCurrentValue();

--- a/src/test/java/competition/subsystems/arm/UnifiedArmTest.java
+++ b/src/test/java/competition/subsystems/arm/UnifiedArmTest.java
@@ -32,7 +32,8 @@ public class UnifiedArmTest extends BaseCompetitionTest {
         assertEquals(0.75, target.y, 0.001);
     }
 
-    @Test @Ignore // Revisit once we set XZ positions rather than raw angles.
+    @Test
+    @Ignore // Revisit once we set XZ positions rather than raw angles.
     public void testTypicalCalibrate() {
         arms.typicalCalibrate();
         var effectorPosition = arms.getCurrentValue();
@@ -40,7 +41,8 @@ public class UnifiedArmTest extends BaseCompetitionTest {
         assertEquals(6, effectorPosition.y, 0.001); // Remember, this is "Z"
     }
 
-    @Test @Ignore // Revisit once we set XZ positions rather than raw angles.
+    @Test
+    @Ignore // Revisit once we set XZ positions rather than raw angles.
     public void testCalibrateAt() {
         arms.calibrateAt(90, 0);
         var effectorPosition = arms.getCurrentValue();


### PR DESCRIPTION
- Setting up polarities for motors and sensors
- Temporarily replaces X/Z effector positioning with simpler angle targeting. This makes for easier testing of the individual arm segments ahead of the full arm control.