### PR TITLE
"Simple" SafeArmRouterCommand

### DIFF
--- a/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
+++ b/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
@@ -49,10 +49,10 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
     // Key angles for the lower and upper arms (in degrees)
     // TODO: Replace these with actual values from testing. For now, safe values of perfectly vertical arm.
     public static XYPair fullyRetractedAngles = new XYPair(90, -90);
-    public static XYPair lowerGoalAngles = new XYPair(90, -90);
-    public static XYPair midGoalAngles = new XYPair(90, -90);
-    public static XYPair highGoalAngles = new XYPair(90, -90);
-    public static XYPair acquireFromCollectorAngles = new XYPair(90, -90);
+    public static XYPair lowerGoalAngles = new XYPair(45, -45);
+    public static XYPair midGoalAngles = new XYPair(50, -15);
+    public static XYPair highGoalAngles = new XYPair(60, 0);
+    public static XYPair acquireFromCollectorAngles = new XYPair(75, -90);
     public static XYPair safeExternalTransitionAngles = new XYPair(90, 0);
 
     double testRangeRadians = 0.17453292519943295; // 10 degrees

--- a/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
+++ b/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
@@ -27,16 +27,33 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
     private final DoubleProperty upperArmTarget;
 
     public enum KeyArmPosition {
-        lowerGoal,
-        midGoal,
-        highGoal,
-        fullyRetracted
+        LowerGoal,
+        MidGoal,
+        HighGoal,
+        FullyRetracted,
+        AcquireFromCollector,
+        SafeExternalTransition
     }
 
+    public enum RobotFacing {
+        Forward,
+        Backward
+    }
+
+    // Key positions for the end effector
     public static XYPair fullyRetractedPosition = new XYPair(0, 0);
     public static XYPair lowerGoalPosition = new XYPair(1*12, 0);
     public static XYPair midGoalPosition = new XYPair(3*12, 2*12);
     public static XYPair highGoalPosition = new XYPair(4*12, 3*12);
+
+    // Key angles for the lower and upper arms (in degrees)
+    // TODO: Replace these with actual values from testing. For now, safe values of perfectly vertical arm.
+    public static XYPair fullyRetractedAngles = new XYPair(90, -90);
+    public static XYPair lowerGoalAngles = new XYPair(90, -90);
+    public static XYPair midGoalAngles = new XYPair(90, -90);
+    public static XYPair highGoalAngles = new XYPair(90, -90);
+    public static XYPair acquireFromCollectorAngles = new XYPair(90, -90);
+    public static XYPair safeExternalTransitionAngles = new XYPair(90, 0);
 
     double testRangeRadians = 0.17453292519943295; // 10 degrees
 
@@ -73,19 +90,72 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
         areBrakesEngaged.set(true);
     }
 
-    public XYPair getKeyArmPosition(KeyArmPosition keyArmPosition){
+    public XYPair getKeyArmCoordinates(KeyArmPosition keyArmPosition, RobotFacing facing){
+        XYPair candidate = new XYPair();
         switch (keyArmPosition){
-            case lowerGoal:
-                return lowerGoalPosition;
-            case midGoal:
-                return midGoalPosition;
-            case highGoal:
-                return highGoalPosition;
-            case fullyRetracted:
-                return fullyRetractedPosition;
+            case LowerGoal:
+                candidate = lowerGoalPosition;
+                break;
+            case MidGoal:
+                candidate = midGoalPosition;
+                break;
+            case HighGoal:
+                candidate = highGoalPosition;
+                break;
+            case FullyRetracted:
+                candidate = fullyRetractedPosition;
+                break;
             default:
-                return new XYPair(0,0);
+                break;
         }
+        if (facing == RobotFacing.Backward){
+            // TODO: mirror the coordinates
+        }
+        return candidate;
+    }
+
+    public XYPair getKeyArmAngles(KeyArmPosition keyArmPosition, RobotFacing facing) {
+        XYPair candidate = new XYPair();
+        switch (keyArmPosition) {
+            case LowerGoal:
+                candidate = lowerGoalAngles;
+                break;
+            case MidGoal:
+                candidate = midGoalAngles;
+                break;
+            case HighGoal:
+                candidate = highGoalAngles;
+                break;
+            case FullyRetracted:
+                candidate = fullyRetractedAngles;
+                break;
+            case AcquireFromCollector:
+                candidate = acquireFromCollectorAngles;
+                break;
+            case SafeExternalTransition:
+                candidate = safeExternalTransitionAngles;
+                break;
+            default:
+                break;
+        }
+        if (facing == RobotFacing.Backward) {
+            candidate = mirrorArmAngles(candidate);
+        }
+        return candidate;
+    }
+
+    public RobotFacing getCurrentArmFacing() {
+        if (lowerArm.getArmPositionInDegrees() <= 90) {
+            return RobotFacing.Forward;
+        } else {
+            return RobotFacing.Backward;
+        }
+    }
+
+    public static XYPair mirrorArmAngles(XYPair angles) {
+        // The lower arm needs to be mirrored around 90 degrees.
+        // The upper arm needs to be mirrored around -90 degrees.
+        return new XYPair(180 - angles.x, -180 - angles.y);
     }
 
     @Override

--- a/src/main/java/competition/subsystems/arm/commands/SetArmsToPositionCommand.java
+++ b/src/main/java/competition/subsystems/arm/commands/SetArmsToPositionCommand.java
@@ -2,14 +2,13 @@ package competition.subsystems.arm.commands;
 
 import competition.subsystems.arm.UnifiedArmSubsystem;
 import xbot.common.command.BaseSetpointCommand;
-import xbot.common.math.XYPair;
 import xbot.common.properties.PropertyFactory;
 
 import javax.inject.Inject;
-import xbot.common.properties.DoubleProperty;
 
 public class SetArmsToPositionCommand extends BaseSetpointCommand {
     UnifiedArmSubsystem.KeyArmPosition targetPosition;
+    UnifiedArmSubsystem.RobotFacing targetFacing;
     private final UnifiedArmSubsystem arms;
 
     @Inject
@@ -17,15 +16,16 @@ public class SetArmsToPositionCommand extends BaseSetpointCommand {
         this.arms = arms;
     }
 
-    public void setTargetPosition(UnifiedArmSubsystem.KeyArmPosition keyArmPosition){
+    public void setTargetPosition(UnifiedArmSubsystem.KeyArmPosition keyArmPosition, UnifiedArmSubsystem.RobotFacing facing){
         this.targetPosition = keyArmPosition;
+        this.targetFacing = facing;
         this.setName("SetArmsTo" + keyArmPosition +"PositionCommand");
     }
     @Override
     public void initialize() {
         log.info("Initializing with target position");
         if(targetPosition != null){
-            arms.setTargetValue(arms.getKeyArmPosition(targetPosition));
+            arms.setTargetValue(arms.getKeyArmCoordinates(targetPosition, targetFacing));
         }
     }
     @Override

--- a/src/main/java/competition/subsystems/arm/commands/SimpleSafeArmRouterCommand.java
+++ b/src/main/java/competition/subsystems/arm/commands/SimpleSafeArmRouterCommand.java
@@ -52,7 +52,12 @@ public class SimpleSafeArmRouterCommand extends BaseSetpointCommand {
             log.info("Need to switch sides; adding a SafeExternalTransition for the other side");
             armPosesToVisit.add(new Pair<>(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, targetRobotFacing));
         }
-        armPosesToVisit.add(new Pair<>(targetArmPosition, targetRobotFacing));
+
+        // If our goal is to go to the SafeExternalTransition point, then we don't need to add it to the list - it
+        // was added by default!
+        if (targetArmPosition != UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition) {
+            armPosesToVisit.add(new Pair<>(targetArmPosition, targetRobotFacing));
+        }
 
         // Then go ahead and set the initial target, so that execute can immediately start looking for that completion.
         setTargetFromFirstEntryInList();

--- a/src/main/java/competition/subsystems/arm/commands/SimpleSafeArmRouterCommand.java
+++ b/src/main/java/competition/subsystems/arm/commands/SimpleSafeArmRouterCommand.java
@@ -1,0 +1,97 @@
+package competition.subsystems.arm.commands;
+
+import competition.subsystems.arm.UnifiedArmSubsystem;
+import edu.wpi.first.math.Pair;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import xbot.common.command.BaseCommand;
+import xbot.common.command.BaseSetpointCommand;
+import xbot.common.math.XYPair;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SimpleSafeArmRouterCommand extends BaseSetpointCommand {
+
+    private final UnifiedArmSubsystem arms;
+    private List<Pair<UnifiedArmSubsystem.KeyArmPosition, UnifiedArmSubsystem.RobotFacing>> armPosesToVisit;
+    private UnifiedArmSubsystem.KeyArmPosition targetArmPosition;
+    private UnifiedArmSubsystem.RobotFacing targetRobotFacing;
+
+    private static Logger log = LogManager.getLogger(SimpleSafeArmRouterCommand.class);
+
+    @Inject
+    public SimpleSafeArmRouterCommand(UnifiedArmSubsystem arms) {
+        super(arms);
+        this.arms = arms;
+        armPosesToVisit = new ArrayList<>();
+    }
+
+    public void setTarget(UnifiedArmSubsystem.KeyArmPosition targetArmPosition, UnifiedArmSubsystem.RobotFacing targetRobotFacing) {
+        this.targetArmPosition = targetArmPosition;
+        this.targetRobotFacing = targetRobotFacing;
+    }
+
+    @Override
+    public void initialize() {
+        log.info("Initializing");
+        UnifiedArmSubsystem.RobotFacing currentArmFacing = arms.getCurrentArmFacing();
+
+        // Some basic rules:
+        // 1) As long as we are on the same side, it should always be safe go to the SafeExternalTransition point.
+        // 2) If we need to swap sides, we need to go to SafeExternalTransition on one side, then the other, before
+        //    going to the target.
+        // Eventually we should use a more sophisticated approach using some kind of configuration space to route
+        // around potential obstacles, but we like to start simple and then optimize what needs to be optimized.
+
+        // Given the rules above, it seems like we should always first go to the SafeExternalTransition point for
+        // the side we are on, and then (if necessary) go to the SafeExternalTransition point for the other side,
+        // before going to our final target point.
+
+        armPosesToVisit.add(new Pair<>(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, currentArmFacing));
+        if (currentArmFacing != targetRobotFacing) {
+            log.info("Need to switch sides; adding a SafeExternalTransition for the other side");
+            armPosesToVisit.add(new Pair<>(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, targetRobotFacing));
+        }
+        armPosesToVisit.add(new Pair<>(targetArmPosition, targetRobotFacing));
+
+        // Then go ahead and set the initial target, so that execute can immediately start looking for that completion.
+        setTargetFromFirstEntryInList();
+    }
+
+    @Override
+    public void execute() {
+        if (armPosesToVisit.size() == 0) {
+            // This shouldn't happen, but just in case, do nothing.
+            return;
+        }
+
+        if (arms.isMaintainerAtGoal()) {
+            // We are at the current target, so we can move on to the next one.
+            armPosesToVisit.remove(0);
+
+            if (armPosesToVisit.size() > 0) {
+                // If there are more targets to visit, set the next one.
+                setTargetFromFirstEntryInList();
+            }
+        }
+
+        // Otherwise, we are still moving to the current target, so do nothing.
+    }
+
+    private void setTargetFromFirstEntryInList() {
+        log.info("Setting target to " + armPosesToVisit.get(0).getFirst() + " " + armPosesToVisit.get(0).getSecond());
+        arms.setTargetValue(
+                arms.getKeyArmAngles(
+                        armPosesToVisit.get(0).getFirst(), // KeyArmPosition
+                        armPosesToVisit.get(0).getSecond() // RobotFacing
+                )
+        );
+    }
+
+    @Override
+    public boolean isFinished() {
+        return armPosesToVisit.size() == 0;
+    }
+}

--- a/src/main/java/competition/subsystems/arm/commands/SimpleSafeArmRouterCommand.java
+++ b/src/main/java/competition/subsystems/arm/commands/SimpleSafeArmRouterCommand.java
@@ -4,9 +4,7 @@ import competition.subsystems.arm.UnifiedArmSubsystem;
 import edu.wpi.first.math.Pair;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import xbot.common.command.BaseCommand;
 import xbot.common.command.BaseSetpointCommand;
-import xbot.common.math.XYPair;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
@@ -58,6 +56,10 @@ public class SimpleSafeArmRouterCommand extends BaseSetpointCommand {
 
         // Then go ahead and set the initial target, so that execute can immediately start looking for that completion.
         setTargetFromFirstEntryInList();
+        // Since we just set the target, the maintainer hasn't had a chance to execute yet and evaluate to see if we
+        // are at that. To avoid premature completion, we will force the subsystem to say the maintainer
+        // is not yet at the goal, since we will be checking that value immediately in execute.
+        arms.setMaintainerIsAtGoal(false);
     }
 
     @Override
@@ -78,6 +80,14 @@ public class SimpleSafeArmRouterCommand extends BaseSetpointCommand {
         }
 
         // Otherwise, we are still moving to the current target, so do nothing.
+    }
+
+    /**
+     * Likely only has value in testing, though it could be used to expose a bit of state to a dashboard.
+     * @return The list of planned positions to visit.
+     */
+    public List<Pair<UnifiedArmSubsystem.KeyArmPosition, UnifiedArmSubsystem.RobotFacing>> getArmPosesToVisit() {
+        return armPosesToVisit;
     }
 
     private void setTargetFromFirstEntryInList() {

--- a/src/test/java/competition/injection/components/CompetitionTestComponent.java
+++ b/src/test/java/competition/injection/components/CompetitionTestComponent.java
@@ -6,6 +6,7 @@ import competition.injection.modules.CompetitionTestModule;
 import competition.subsystems.arm.LowerArmSegment;
 import competition.subsystems.arm.UnifiedArmSubsystem;
 import competition.subsystems.arm.UpperArmSegment;
+import competition.subsystems.arm.commands.SimpleSafeArmRouterCommand;
 import competition.subsystems.arm.commands.UnifiedArmMaintainer;
 import competition.subsystems.claw.ClawSubsystem;
 import competition.subsystems.claw.CloseClawCommand;
@@ -54,4 +55,6 @@ public abstract class CompetitionTestComponent extends BaseRobotComponent {
     public abstract CloseClawCommand closeClawCommand();
 
     public abstract UnifiedArmMaintainer unifiedArmMaintainer();
+
+    public abstract SimpleSafeArmRouterCommand simpleSafeArmRouterCommand();
 }

--- a/src/test/java/competition/subsystems/arm/SimpleSafeArmRouterCommandTest.java
+++ b/src/test/java/competition/subsystems/arm/SimpleSafeArmRouterCommandTest.java
@@ -166,6 +166,17 @@ public class SimpleSafeArmRouterCommandTest extends BaseCompetitionTest {
         assertTrue(routerCommand.isFinished());
     }
 
+    @Test
+    public void testSafeExternalTransitionAsGoal() {
+        setArmAngles(85, -90);
+        routerCommand.setTarget(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Backward);
+        routerCommand.initialize();
+
+        assertTrue(routerCommand.getArmPosesToVisit().size() == 2);
+        checkCurrentTarget(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Forward);
+        checkArbitraryTarget(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Backward, 1);
+    }
+
     private void setArmAngles(double lowerArmAngle, double upperArmAngle) {
         ((MockDutyCycleEncoder)arms.lowerArm.absoluteEncoder).setRawPosition(lowerArmAngle/360.0);
         ((MockDutyCycleEncoder)arms.upperArm.absoluteEncoder).setRawPosition(upperArmAngle/360.0);
@@ -177,7 +188,11 @@ public class SimpleSafeArmRouterCommandTest extends BaseCompetitionTest {
     }
 
     private void checkCurrentTarget(UnifiedArmSubsystem.KeyArmPosition position, UnifiedArmSubsystem.RobotFacing facing) {
-        assertEquals(position, routerCommand.getArmPosesToVisit().get(0).getFirst());
-        assertEquals(facing, routerCommand.getArmPosesToVisit().get(0).getSecond());
+        checkArbitraryTarget(position, facing, 0);
+    }
+
+    private void checkArbitraryTarget(UnifiedArmSubsystem.KeyArmPosition position, UnifiedArmSubsystem.RobotFacing facing, int index) {
+        assertEquals(position, routerCommand.getArmPosesToVisit().get(index).getFirst());
+        assertEquals(facing, routerCommand.getArmPosesToVisit().get(index).getSecond());
     }
 }

--- a/src/test/java/competition/subsystems/arm/SimpleSafeArmRouterCommandTest.java
+++ b/src/test/java/competition/subsystems/arm/SimpleSafeArmRouterCommandTest.java
@@ -1,0 +1,183 @@
+package competition.subsystems.arm;
+
+import competition.BaseCompetitionTest;
+import competition.subsystems.arm.commands.SimpleSafeArmRouterCommand;
+import competition.subsystems.arm.commands.UnifiedArmMaintainer;
+import org.junit.Test;
+import xbot.common.controls.sensors.mock_adapters.MockDutyCycleEncoder;
+import xbot.common.math.XYPair;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SimpleSafeArmRouterCommandTest extends BaseCompetitionTest {
+
+    private SimpleSafeArmRouterCommand routerCommand;
+    private UnifiedArmSubsystem arms;
+    private UnifiedArmMaintainer maintainer;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        arms = getInjectorComponent().unifiedArmSubsystem();
+        arms.setIsCalibrated(true);
+        maintainer = getInjectorComponent().unifiedArmMaintainer();
+        routerCommand = getInjectorComponent().simpleSafeArmRouterCommand();
+    }
+
+    @Test
+    public void testSimpleRoute() {
+        // Same facing, just going from neutral state to high state.
+        setArmAngles(85, -90);
+
+        // -------------------------------------------
+        // Going to first transition point
+        // -------------------------------------------
+
+        routerCommand.setTarget(UnifiedArmSubsystem.KeyArmPosition.HighGoal, UnifiedArmSubsystem.RobotFacing.Forward);
+
+        routerCommand.initialize();
+        // Should be going to same-side transition point
+        checkCurrentTarget(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Forward);
+        routerCommand.execute();
+        // Nothing should change on first execution.
+        checkCurrentTarget(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Forward);
+        assertFalse(routerCommand.isFinished());
+
+        maintainer.initialize();
+        maintainer.execute();
+
+        // Run the router again - since no change in the arm, we shouldn't have any change in the target.
+        routerCommand.execute();
+        checkCurrentTarget(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Forward);
+        assertFalse(routerCommand.isFinished());
+
+        // Now move the arm to the transition point.
+        setArmAnglesFromKeyArmPositionAndFacing(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Forward);
+        maintainer.execute();
+        // We'll need to advance time and maintain again to get the "is at target" flag to be set.
+        assertFalse(arms.isMaintainerAtGoal());
+        timer.advanceTimeInSecondsBy(10);
+        maintainer.execute();
+        assertTrue(arms.isMaintainerAtGoal());
+
+        // -------------------------------------------
+        // Going to goal point
+        // -------------------------------------------
+
+        // This should cause the router to move to the next target.
+        routerCommand.execute();
+        checkCurrentTarget(UnifiedArmSubsystem.KeyArmPosition.HighGoal, UnifiedArmSubsystem.RobotFacing.Forward);
+        assertFalse(routerCommand.isFinished());
+
+        maintainer.execute();
+        // Now move the arm to the high goal point.
+        setArmAnglesFromKeyArmPositionAndFacing(UnifiedArmSubsystem.KeyArmPosition.HighGoal, UnifiedArmSubsystem.RobotFacing.Forward);
+        maintainer.execute();
+        assertFalse(arms.isMaintainerAtGoal());
+        // We'll need to advance time and maintain again to get the "is at target" flag to be set.
+        timer.advanceTimeInSecondsBy(10);
+        maintainer.execute();
+        assertTrue(arms.isMaintainerAtGoal());
+
+        // This should cause the router to remove the target and declare it is finished.
+        routerCommand.execute();
+        assertTrue(routerCommand.getArmPosesToVisit().size() == 0);
+        assertTrue(routerCommand.isFinished());
+    }
+
+    @Test
+    public void testCrossFacingRoute() {
+        // Same facing, just going from neutral state to high state.
+        setArmAngles(85, -90);
+
+        // -------------------------------------------
+        // Going to first transition point (forward)
+        // -------------------------------------------
+
+        routerCommand.setTarget(UnifiedArmSubsystem.KeyArmPosition.HighGoal, UnifiedArmSubsystem.RobotFacing.Backward);
+
+        routerCommand.initialize();
+        // Should be going to same-side transition point
+        checkCurrentTarget(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Forward);
+        routerCommand.execute();
+        // Nothing should change on first execution.
+        checkCurrentTarget(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Forward);
+        assertFalse(routerCommand.isFinished());
+
+        maintainer.initialize();
+        maintainer.execute();
+
+        // Run the router again - since no change in the arm, we shouldn't have any change in the target.
+        routerCommand.execute();
+        checkCurrentTarget(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Forward);
+        assertFalse(routerCommand.isFinished());
+
+        // Now move the arm to the transition point.
+        setArmAnglesFromKeyArmPositionAndFacing(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Forward);
+        maintainer.execute();
+        // We'll need to advance time and maintain again to get the "is at target" flag to be set.
+        assertFalse(arms.isMaintainerAtGoal());
+        timer.advanceTimeInSecondsBy(10);
+        maintainer.execute();
+        assertTrue(arms.isMaintainerAtGoal());
+
+        // -------------------------------------------
+        // Going to second transition point (backward)
+        // -------------------------------------------
+
+        // This should cause the router to move to the next target.
+        routerCommand.execute();
+        checkCurrentTarget(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Backward);
+        assertFalse(routerCommand.isFinished());
+
+        maintainer.execute();
+        // Now move the arm to the transition point.
+        setArmAnglesFromKeyArmPositionAndFacing(UnifiedArmSubsystem.KeyArmPosition.SafeExternalTransition, UnifiedArmSubsystem.RobotFacing.Backward);
+        maintainer.execute();
+        // We'll need to advance time and maintain again to get the "is at target" flag to be set.
+        assertFalse(arms.isMaintainerAtGoal());
+        timer.advanceTimeInSecondsBy(10);
+        maintainer.execute();
+        assertTrue(arms.isMaintainerAtGoal());
+
+        // -------------------------------------------
+        // Going to goal point
+        // -------------------------------------------
+
+        // This should cause the router to move to the next target.
+        routerCommand.execute();
+        checkCurrentTarget(UnifiedArmSubsystem.KeyArmPosition.HighGoal, UnifiedArmSubsystem.RobotFacing.Backward);
+        assertFalse(routerCommand.isFinished());
+
+        maintainer.execute();
+        // Now move the arm to the high goal point.
+        setArmAnglesFromKeyArmPositionAndFacing(UnifiedArmSubsystem.KeyArmPosition.HighGoal, UnifiedArmSubsystem.RobotFacing.Backward);
+        maintainer.execute();
+        // We'll need to advance time and maintain again to get the "is at target" flag to be set.
+        timer.advanceTimeInSecondsBy(10);
+        maintainer.execute();
+        assertTrue(arms.isMaintainerAtGoal());
+
+        // This should cause the router to remove the target and declare it is finished.
+        routerCommand.execute();
+        assertTrue(routerCommand.getArmPosesToVisit().size() == 0);
+        assertTrue(routerCommand.isFinished());
+    }
+
+    private void setArmAngles(double lowerArmAngle, double upperArmAngle) {
+        ((MockDutyCycleEncoder)arms.lowerArm.absoluteEncoder).setRawPosition(lowerArmAngle/360.0);
+        ((MockDutyCycleEncoder)arms.upperArm.absoluteEncoder).setRawPosition(upperArmAngle/360.0);
+    }
+
+    private void setArmAnglesFromKeyArmPositionAndFacing(UnifiedArmSubsystem.KeyArmPosition position, UnifiedArmSubsystem.RobotFacing facing) {
+        XYPair angles = arms.getKeyArmAngles(position, facing);
+        setArmAngles(angles.x, angles.y);
+    }
+
+    private void checkCurrentTarget(UnifiedArmSubsystem.KeyArmPosition position, UnifiedArmSubsystem.RobotFacing facing) {
+        assertEquals(position, routerCommand.getArmPosesToVisit().get(0).getFirst());
+        assertEquals(facing, routerCommand.getArmPosesToVisit().get(0).getSecond());
+    }
+}

--- a/src/test/java/competition/subsystems/arm/UnifiedArmTest.java
+++ b/src/test/java/competition/subsystems/arm/UnifiedArmTest.java
@@ -94,6 +94,27 @@ public class UnifiedArmTest extends BaseCompetitionTest {
         assertTrue(((MockCANSparkMax)arms.upperArm.rightMotor).getReference() < -10);
     }
 
+    @Test
+    public void testMirrorArmAngles() {
+        XYPair perfectlyVertical = new XYPair(90, -90);
+        XYPair mirroredVertical = UnifiedArmSubsystem.mirrorArmAngles(perfectlyVertical);
+        // There should be no change if we mirror around the center point of 90 for the lower arm and -90 for the upper.
+        assertEquals(90, mirroredVertical.x, 0.001);
+        assertEquals(-90, mirroredVertical.y, 0.001);
+
+        // We should see some changes using angles offset by 45 degrees.
+        XYPair offset = new XYPair(135, -45);
+        XYPair mirroredOffset = UnifiedArmSubsystem.mirrorArmAngles(offset);
+        assertEquals(45, mirroredOffset.x, 0.001);
+        assertEquals(-135, mirroredOffset.y, 0.001);
+
+        // Let's check some angles that are more than 135 degrees away from the mirror point.
+        XYPair farAway = new XYPair(-45, 45);
+        XYPair mirroredFarAway = UnifiedArmSubsystem.mirrorArmAngles(farAway);
+        assertEquals(225, mirroredFarAway.x, 0.001);
+        assertEquals(-225, mirroredFarAway.y, 0.001);
+    }
+
     private void checkArmPowers(double lowerPower, double upperPower) {
         assertEquals(lowerPower, arms.lowerArm.rightMotor.get(), 0.001);
         assertEquals(upperPower, arms.upperArm.rightMotor.get(), 0.001);


### PR DESCRIPTION
Eventually we need a smart way to move from point to point. In the interim, here is a very dumb way that should mostly prevent the robot from shattering itself to pieces:

* Whenever you want to move to a target point, simultaneously move the lower arm to perfectly vertical and the upper arm to 0 degrees.
  * (If the arm is already on the back side of the robot, move the lower arm to perfectly vertical and the upper arm to -180 degrees instead.)
 * If you need to "swap sides" on the robot, follow this by holding the lower arm vertical and rotating the upper arm through its entire bottom arc (180 or -180 degrees depending on your start position) so it's facing out horizontally on the other side. If you were already on the right side to begin with, skip this step.
* Once that is done, move to your target position.