### PR TITLE
Compensate arm positioning based on robot pitch.

### DIFF
--- a/src/main/java/competition/subsystems/arm/LowerArmSegment.java
+++ b/src/main/java/competition/subsystems/arm/LowerArmSegment.java
@@ -5,6 +5,7 @@ import javax.inject.Singleton;
 
 import com.revrobotics.CANSparkMax;
 import competition.electrical_contract.ElectricalContract;
+import competition.subsystems.pose.PoseSubsystem;
 import edu.wpi.first.networktables.DoubleEntry;
 import xbot.common.controls.actuators.XCANSparkMax;
 import xbot.common.controls.actuators.XCANSparkMax.XCANSparkMaxFactory;
@@ -31,8 +32,8 @@ public class LowerArmSegment extends ArmSegment {
 
     @Inject
     public LowerArmSegment(XCANSparkMaxFactory sparkMaxFactory, XDutyCycleEncoder.XDutyCycleEncoderFactory dutyCycleEncoderFactory,
-                           ElectricalContract eContract, PropertyFactory propFactory){
-        super("UnifiedArmSubsystem/LowerArm", propFactory, 270, -90);
+                           ElectricalContract eContract, PropertyFactory propFactory, PoseSubsystem pose){
+        super("UnifiedArmSubsystem/LowerArm", propFactory, pose, 270, -90);
         String prefix = "UnifiedArmSubsystem/LowerArm";
 
         propFactory.setPrefix(prefix);

--- a/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
+++ b/src/main/java/competition/subsystems/arm/UnifiedArmSubsystem.java
@@ -162,8 +162,8 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
     public XYPair getCurrentValue() {
 
         return new XYPair(
-                lowerArm.getArmPositionFromAbsoluteEncoderInDegrees(),
-                upperArm.getArmPositionFromAbsoluteEncoderInDegrees()
+                lowerArm.getArmPositionInDegrees(),
+                upperArm.getArmPositionInDegrees()
         );
         // Eventually do the smart thing. For now, just do angles.
         /*
@@ -210,6 +210,11 @@ public class UnifiedArmSubsystem extends BaseSetpointSubsystem<XYPair> {
     @Override
     public boolean isCalibrated() {
         return calibratedProp.get();
+    }
+
+    public void setPitchCompensation(boolean enabled) {
+        this.lowerArm.setPitchCompensation(enabled);
+        this.upperArm.setPitchCompensation(enabled);
     }
 
     public void setIsCalibrated(boolean isCalibrated) {

--- a/src/main/java/competition/subsystems/arm/UpperArmSegment.java
+++ b/src/main/java/competition/subsystems/arm/UpperArmSegment.java
@@ -5,6 +5,7 @@ import javax.inject.Singleton;
 
 import com.revrobotics.CANSparkMax;
 import competition.electrical_contract.ElectricalContract;
+import competition.subsystems.pose.PoseSubsystem;
 import xbot.common.controls.actuators.XCANSparkMax;
 import xbot.common.controls.actuators.XCANSparkMax.XCANSparkMaxFactory;
 import xbot.common.controls.sensors.XDutyCycleEncoder;
@@ -28,8 +29,8 @@ public class UpperArmSegment extends ArmSegment {
 
     @Inject
     public UpperArmSegment(XCANSparkMaxFactory sparkMaxFactory, XDutyCycleEncoder.XDutyCycleEncoderFactory dutyCycleEncoderFactory,
-                           ElectricalContract eContract, PropertyFactory propFactory){
-        super("UnifiedArmSubsystem/UpperArm", propFactory, 90, -270);
+                           ElectricalContract eContract, PropertyFactory propFactory, PoseSubsystem pose){
+        super("UnifiedArmSubsystem/UpperArm", propFactory, pose, 90, -270);
         String prefix = "UnifiedArmSubsystem/UpperArm";
         propFactory.setPrefix(prefix);
         degreesPerMotorRotationProp = propFactory.createPersistentProperty("degreesPerMotorRotation",1.26);


### PR DESCRIPTION
This allows keeping the arm completely vertical during a charging station mount, to avoid the arm changing the position of the center of mass above the robot.