### PR TITLE
Move arm end-effector in X-Z space

### DIFF
--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -6,6 +6,7 @@ import competition.auto_programs.ScoreCubeHighThenLeaveCommandGroup;
 import competition.subsystems.arm.UnifiedArmSubsystem;
 import competition.subsystems.arm.UnifiedArmSubsystem.KeyArmPosition;
 import competition.subsystems.arm.UnifiedArmSubsystem.RobotFacing;
+import competition.subsystems.arm.commands.ControlEndEffectorPositionCommand;
 import competition.subsystems.arm.commands.SimpleSafeArmRouterCommand;
 import competition.subsystems.claw.ClawSubsystem;
 import competition.subsystems.collector.CollectorSubsystem;
@@ -192,6 +193,7 @@ public class OperatorCommandMap {
             UnifiedArmSubsystem arm,
             ClawSubsystem claw,
             Provider<SimpleSafeArmRouterCommand> armPositionCommandProvider,
+            Provider<ControlEndEffectorPositionCommand> endEffectorPositionCommandProvider,
             SimpleSafeArmRouterCommand router,
             ScoreCubeHighThenLeaveCommandGroup scoreCubeHigh,
             CollectorSubsystem collector) {
@@ -284,6 +286,20 @@ public class OperatorCommandMap {
         oi.operatorGamepad.getifAvailable(XboxButton.LeftTrigger).whileTrue(collector.getEjectThenStopCommand());
 
         SmartDashboard.putData("ScoreCubeHigh", scoreCubeHigh);
+
+        ControlEndEffectorPositionCommand moveUp = endEffectorPositionCommandProvider.get();
+        moveUp.setDirection(new XYPair(0, 1));
+        ControlEndEffectorPositionCommand moveForward = endEffectorPositionCommandProvider.get();
+        moveForward.setDirection(new XYPair(1, 0));
+        ControlEndEffectorPositionCommand moveBack = endEffectorPositionCommandProvider.get();
+        moveBack.setDirection(new XYPair(-1, 0));
+        ControlEndEffectorPositionCommand moveDown = endEffectorPositionCommandProvider.get();
+        moveDown.setDirection(new XYPair(0, -1));
+
+        oi.experimentalGamepad.getPovIfAvailable(0).whileTrue(moveUp);
+        oi.experimentalGamepad.getPovIfAvailable(90).whileTrue(moveForward);
+        oi.experimentalGamepad.getPovIfAvailable(180).whileTrue(moveDown);
+        oi.experimentalGamepad.getPovIfAvailable(270).whileTrue(moveBack);
     }
 
 }

--- a/src/main/java/competition/operator_interface/OperatorInterface.java
+++ b/src/main/java/competition/operator_interface/OperatorInterface.java
@@ -19,6 +19,7 @@ import xbot.common.properties.PropertyFactory;
 public class OperatorInterface {
     public XXboxController driverGamepad;
     public XXboxController operatorGamepad;
+    public XXboxController experimentalGamepad;
     
     final DoubleProperty driverDeadband;
     final DoubleProperty operatorDeadband;
@@ -32,6 +33,10 @@ public class OperatorInterface {
         operatorGamepad = controllerFactory.create(1);
         operatorGamepad.setLeftInversion(false, true);
         operatorGamepad.setRightInversion(false, true);
+
+        experimentalGamepad = controllerFactory.create(2);
+        experimentalGamepad.setLeftInversion(false, true);
+        experimentalGamepad.setRightInversion(false, true);
 
         pf.setPrefix("OperatorInterface");
         driverDeadband = pf.createPersistentProperty("Driver Deadband", 0.12);

--- a/src/main/java/competition/subsystems/arm/ArmPositionSolver.java
+++ b/src/main/java/competition/subsystems/arm/ArmPositionSolver.java
@@ -2,6 +2,7 @@ package competition.subsystems.arm;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import xbot.common.math.MathUtils;
+import xbot.common.math.WrappedRotation2d;
 import xbot.common.math.XYPair;
 
 public class ArmPositionSolver {
@@ -17,13 +18,14 @@ public class ArmPositionSolver {
 
     /**
      * Calculate the target rotation of each arm joint given a target end-effector position
-     * @param targetX The distance in front of or behind the robot (in inches) relative to the fixed arm pivot.
-     * @param targetZ The distance above or below the fixed pivot (in inches)
+     * @param targetEndEffectorPosition X: The distance in front of or behind the robot (in inches) relative to the fixed arm pivot.
+     *                                  Y: The distance above or below the fixed pivot (in inches).
+     * @param currentAngles X: The current lower joint angle.
+     *                      Y: The current upper joint angle.
      */
-    public ArmPositionState solveArmJointPositions(double targetX, double targetZ) {
+    public ArmPositionState solveArmJointPositions(XYPair targetEndEffectorPosition, XYPair currentAngles) {
         // The arm is made up of two links. LinkA is fixed to a pivot point on the base of the robot (Joint1).
-        // LinkA is a four-bar linkage. LinkB is attached to the other end of LinkA at Joint2. LinkA is a four-bar
-        // linkage, so Joint2's rotation is not affected by the rotation of Joint1.
+        // LinkB is attached to the other end of LinkA at Joint2.
 
         // We can use the cosine law to calculate the angles of a triangle formed by the two links (LA, LB)
         //        J2
@@ -32,8 +34,6 @@ public class ArmPositionSolver {
         //    /       \
         //  J1  - - -  EE
         // A = arccos((b^2 + c^2 - a^2) / 2bc)
-
-        XYPair targetEndEffectorPosition = new XYPair(targetX, targetZ);
 
         // Check that the target position is within reach
         if (targetEndEffectorPosition.getMagnitude() > this.configuration.getUpperArmLength() + this.configuration.getLowerArmLength()) {
@@ -50,22 +50,34 @@ public class ArmPositionSolver {
                 this.configuration.getUpperArmLength(),
                 targetEndEffectorPosition.getMagnitude()
         );
-        double angleHorizonToLowerJoint = targetEndEffectorPosition.getAngle();
 
-        Rotation2d angleLowerJointRelativeToHorizon = Rotation2d.fromDegrees(angleLowerJoint)
-                .plus(Rotation2d.fromDegrees(angleHorizonToLowerJoint));
-        Rotation2d angleUpperJointRelativeToHorizon = angleLowerJointRelativeToHorizon
-                .plus(Rotation2d.fromDegrees(angleUpperJoint))
-                .plus(Rotation2d.fromDegrees(180));
+        // Two possible solutions, depending on if we started with upper arm angle greater than or less than zero.
+        // We don't want to cross this, because it will produce a drastically different solution.
+        if (currentAngles.y >= 0) {
+            double angleLowerJointRelativeToHorizon = angleLowerJoint + targetEndEffectorPosition.getAngle();
 
-        return new ArmPositionState(angleLowerJointRelativeToHorizon, angleUpperJointRelativeToHorizon, true);
+            XYPair lowerArmEndpoint = new XYPair(Rotation2d.fromDegrees(angleLowerJointRelativeToHorizon)).scale(configuration.getLowerArmLength());
+            XYPair upperArmEndpoint = new XYPair(Rotation2d.fromDegrees(angleLowerJoint + angleUpperJoint)).scale(configuration.getLowerArmLength());
+
+            return new ArmPositionState(
+                    Rotation2d.fromDegrees(angleLowerJointRelativeToHorizon),
+                    Rotation2d.fromDegrees(angleUpperJoint), true);
+        } else {
+            double angleLowerJointRelativeToHorizon = targetEndEffectorPosition.getAngle() - angleLowerJoint;
+
+            XYPair lowerArmEndpoint = new XYPair(Rotation2d.fromDegrees(angleLowerJointRelativeToHorizon)).scale(configuration.getLowerArmLength());
+            XYPair upperArmEndpoint = new XYPair(Rotation2d.fromDegrees(angleLowerJoint + angleUpperJoint)).scale(configuration.getLowerArmLength());
+
+            return new ArmPositionState(
+                    Rotation2d.fromDegrees(angleLowerJointRelativeToHorizon),
+                    Rotation2d.fromDegrees(-angleUpperJoint), true);
+        }
     }
 
     private static double getAngleFromCosineLaw(double adjacent1Length, double adjacent2length, double oppositeLength) {
-        return Math.toDegrees(
-                Math.acos(
-                    (Math.pow(adjacent1Length, 2) + Math.pow(adjacent2length, 2) - Math.pow(oppositeLength, 2))
-                            / (2 * adjacent1Length * adjacent2length)));
+        double value = (Math.pow(adjacent1Length, 2) + Math.pow(adjacent2length, 2) - Math.pow(oppositeLength, 2))
+                / (2 * adjacent1Length * adjacent2length);
+        return Math.toDegrees(Math.acos(value));
     }
 
     public XYPair getPositionFromRadians(double lowerArmAngleRadians, double upperArmAngleRadians) {
@@ -75,12 +87,10 @@ public class ArmPositionSolver {
 
         double adjustedUpperArmAngleRadians = upperArmAngleRadians + (lowerArmAngleRadians + MathUtils.Tau/2.0);
 
-        return new XYPair(
-                Math.cos(lowerArmAngleRadians)*configuration.getLowerArmLength()
-                +Math.cos(adjustedUpperArmAngleRadians)*configuration.getUpperArmLength(),
-                Math.sin(lowerArmAngleRadians)*configuration.getLowerArmLength()
-                + Math.sin(adjustedUpperArmAngleRadians)*configuration.getUpperArmLength()
-        );
+        XYPair lowerArm = new XYPair(new Rotation2d(lowerArmAngleRadians)).scale(configuration.getLowerArmLength());
+        XYPair upperArm = new XYPair(new WrappedRotation2d(adjustedUpperArmAngleRadians)).scale(configuration.getUpperArmLength());
+
+        return lowerArm.add(upperArm);
     }
 
     /**

--- a/src/main/java/competition/subsystems/arm/commands/ControlEndEffectorPositionCommand.java
+++ b/src/main/java/competition/subsystems/arm/commands/ControlEndEffectorPositionCommand.java
@@ -1,0 +1,54 @@
+package competition.subsystems.arm.commands;
+
+import competition.subsystems.arm.ArmPositionState;
+import competition.subsystems.arm.UnifiedArmSubsystem;
+import xbot.common.command.BaseSetpointCommand;
+import xbot.common.math.XYPair;
+import xbot.common.properties.DoubleProperty;
+import xbot.common.properties.PropertyFactory;
+
+import javax.inject.Inject;
+
+/**
+ * Moves the end-effector by some distance in X-Z space
+ */
+public class ControlEndEffectorPositionCommand extends BaseSetpointCommand {
+
+    private final UnifiedArmSubsystem arm;
+    private final DoubleProperty positionChangePerStep;
+
+    private XYPair movementVector = new XYPair(0, 0);
+    private XYPair position;
+
+    @Inject
+    public ControlEndEffectorPositionCommand(PropertyFactory pf, UnifiedArmSubsystem arm) {
+        super(arm);
+        this.arm = arm;
+        pf.setPrefix(this);
+        this.positionChangePerStep = pf.createPersistentProperty("Position change per step", 0.5);
+    }
+
+    public void setDirection(XYPair vector) {
+        movementVector = vector.clone().scale(this.positionChangePerStep.get());
+    }
+
+    @Override
+    public void initialize() {
+        position = arm.getCurrentXZCoordinates();
+        arm.setDisableBrake(true);
+    }
+
+    @Override
+    public void execute() {
+        position.add(movementVector);
+
+        ArmPositionState newTargets = arm.solver.solveArmJointPositions(position, arm.getCurrentValue());
+        arm.setTargetValue(new XYPair(newTargets.getLowerJointRotation().getDegrees(), newTargets.getUpperJointRotation().getDegrees()));
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        super.end(interrupted);
+        arm.setDisableBrake(false);
+    }
+}

--- a/src/main/java/competition/subsystems/arm/commands/UnifiedArmMaintainer.java
+++ b/src/main/java/competition/subsystems/arm/commands/UnifiedArmMaintainer.java
@@ -98,11 +98,11 @@ public class UnifiedArmMaintainer extends BaseMaintainerCommand<XYPair> {
     private void changeBrakeStateBasedOnError() {
         double lowerArmError = Math.abs(unifiedArm.getCurrentValue().x - unifiedArm.getTargetValue().x);
 
-        if (lowerArmError < lowerArmErrorThresholdToEngageBrake.get()) {
+        if (lowerArmError < lowerArmErrorThresholdToEngageBrake.get() && !unifiedArm.getDisableBrake()) {
             unifiedArm.setBrake(true);
         }
 
-        if (lowerArmError > lowerArmErrorThresholdToDisengageBrake.get()) {
+        if (lowerArmError > lowerArmErrorThresholdToDisengageBrake.get() || unifiedArm.getDisableBrake()) {
             unifiedArm.setBrake(false);
         }
     }

--- a/src/test/java/competition/injection/components/CompetitionTestComponent.java
+++ b/src/test/java/competition/injection/components/CompetitionTestComponent.java
@@ -6,6 +6,7 @@ import competition.injection.modules.CompetitionTestModule;
 import competition.subsystems.arm.LowerArmSegment;
 import competition.subsystems.arm.UnifiedArmSubsystem;
 import competition.subsystems.arm.UpperArmSegment;
+import competition.subsystems.arm.commands.ControlEndEffectorPositionCommand;
 import competition.subsystems.arm.commands.SimpleSafeArmRouterCommand;
 import competition.subsystems.arm.commands.UnifiedArmMaintainer;
 import competition.subsystems.claw.ClawSubsystem;
@@ -44,7 +45,9 @@ public abstract class CompetitionTestComponent extends BaseRobotComponent {
 
     public abstract UpperArmSegment upperArmSegment();
 
-    public  abstract ControlArmsWithJoyStickCommand controlArmsWithJoyStickCommand();
+    public abstract ControlArmsWithJoyStickCommand controlArmsWithJoyStickCommand();
+
+    public abstract ControlEndEffectorPositionCommand controlEndEffectorPositionCommand();
 
     public abstract UnifiedArmSubsystem unifiedArmSubsystem();
 

--- a/src/test/java/competition/subsystems/arm/ArmPositionSolverTest.java
+++ b/src/test/java/competition/subsystems/arm/ArmPositionSolverTest.java
@@ -20,9 +20,9 @@ public class ArmPositionSolverTest extends BaseCompetitionTest {
                 Rotation2d.fromDegrees(-180), Rotation2d.fromDegrees(180));
         ArmPositionSolver solver = new ArmPositionSolver(configuration);
 
-        ArmPositionState calculatedGoal = solver.solveArmJointPositions(2, 0);
+        ArmPositionState calculatedGoal = solver.solveArmJointPositions(new XYPair(2, 0), new XYPair(90, 0));
         assertEquals(Rotation2d.fromDegrees(0), calculatedGoal.getLowerJointRotation());
-        assertEquals(Rotation2d.fromDegrees(0), calculatedGoal.getUpperJointRotation());
+        assertEquals(Rotation2d.fromDegrees(180), calculatedGoal.getUpperJointRotation());
         assertTrue(calculatedGoal.isSolveable());
     }
 
@@ -34,7 +34,7 @@ public class ArmPositionSolverTest extends BaseCompetitionTest {
                 Rotation2d.fromDegrees(-180), Rotation2d.fromDegrees(180));
         ArmPositionSolver solver = new ArmPositionSolver(configuration);
 
-        ArmPositionState calculatedGoal = solver.solveArmJointPositions(-2, 0);
+        ArmPositionState calculatedGoal = solver.solveArmJointPositions(new XYPair(-2, 0), new XYPair(90, 0));
         assertEquals(Rotation2d.fromDegrees(180), calculatedGoal.getLowerJointRotation());
         assertEquals(Rotation2d.fromDegrees(180), calculatedGoal.getUpperJointRotation());
         assertTrue(calculatedGoal.isSolveable());
@@ -48,9 +48,9 @@ public class ArmPositionSolverTest extends BaseCompetitionTest {
                 Rotation2d.fromDegrees(-180), Rotation2d.fromDegrees(180));
         ArmPositionSolver solver = new ArmPositionSolver(configuration);
 
-        ArmPositionState calculatedGoal = solver.solveArmJointPositions(0, 2);
+        ArmPositionState calculatedGoal = solver.solveArmJointPositions(new XYPair(0, 2), new XYPair(90, 0));
         assertEquals(Rotation2d.fromDegrees(90), calculatedGoal.getLowerJointRotation());
-        assertEquals(Rotation2d.fromDegrees(90), calculatedGoal.getUpperJointRotation());
+        assertEquals(Rotation2d.fromDegrees(180), calculatedGoal.getUpperJointRotation());
         assertTrue(calculatedGoal.isSolveable());
     }
 
@@ -62,9 +62,9 @@ public class ArmPositionSolverTest extends BaseCompetitionTest {
                 Rotation2d.fromDegrees(-180), Rotation2d.fromDegrees(180));
         ArmPositionSolver solver = new ArmPositionSolver(configuration);
 
-        ArmPositionState calculatedGoal = solver.solveArmJointPositions(1, 0);
+        ArmPositionState calculatedGoal = solver.solveArmJointPositions(new XYPair(1, 0), new XYPair(90., 0));
         assertEquals(Rotation2d.fromDegrees(60), calculatedGoal.getLowerJointRotation());
-        assertEquals(Rotation2d.fromDegrees(-60), calculatedGoal.getUpperJointRotation());
+        assertEquals(Rotation2d.fromDegrees(60), calculatedGoal.getUpperJointRotation());
         assertTrue(calculatedGoal.isSolveable());
     }
 
@@ -76,7 +76,7 @@ public class ArmPositionSolverTest extends BaseCompetitionTest {
                 Rotation2d.fromDegrees(-180), Rotation2d.fromDegrees(180));
         ArmPositionSolver solver = new ArmPositionSolver(configuration);
 
-        ArmPositionState calculatedGoal = solver.solveArmJointPositions(3, 0);
+        ArmPositionState calculatedGoal = solver.solveArmJointPositions(new XYPair(3, 0), new XYPair(90, 0));
         assertFalse(calculatedGoal.isSolveable());
     }
 

--- a/src/test/java/competition/subsystems/arm/ControlEndEffectorPositionCommandTest.java
+++ b/src/test/java/competition/subsystems/arm/ControlEndEffectorPositionCommandTest.java
@@ -1,0 +1,101 @@
+package competition.subsystems.arm;
+
+import competition.BaseCompetitionTest;
+import competition.subsystems.arm.commands.ControlEndEffectorPositionCommand;
+import competition.subsystems.arm.commands.UnifiedArmMaintainer;
+import org.junit.Test;
+import xbot.common.controls.sensors.mock_adapters.MockDutyCycleEncoder;
+import xbot.common.math.XYPair;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ControlEndEffectorPositionCommandTest extends BaseCompetitionTest {
+
+    private ControlEndEffectorPositionCommand command;
+    private UnifiedArmSubsystem arm;
+    private UnifiedArmMaintainer maintainer;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        command = getInjectorComponent().controlEndEffectorPositionCommand();
+        arm = getInjectorComponent().unifiedArmSubsystem();
+        arm.setIsCalibrated(true);
+        maintainer = getInjectorComponent().unifiedArmMaintainer();
+    }
+
+    @Test
+    public void testMoveArmWithCommand() {
+        setArmAngles(45, 90);
+        XYPair currentPosition = arm.getCurrentXZCoordinates();
+        assertEquals(54.80, currentPosition.x, 0.01);
+        assertEquals(8.13, currentPosition.y, 0.01);
+
+        command.setDirection(new XYPair(-1, 0));
+        command.initialize();
+        command.execute();
+
+        setArmAngles(arm.getTargetValue().x, arm.getTargetValue().y);
+        maintainer.execute();
+        timer.advanceTimeInSecondsBy(10);
+        maintainer.execute();
+
+        assertTrue(arm.isMaintainerAtGoal());
+        command.end(false);
+
+        assertEquals(45.45, arm.lowerArm.getArmPositionInDegrees(), 0.01);
+        assertEquals(88.94, arm.upperArm.getArmPositionInDegrees(), 0.01);
+    }
+
+    @Test
+    public void testMoveArmWithCommand2() {
+        setArmAngles(103, 56);
+        XYPair currentPosition = arm.getCurrentXZCoordinates();
+        assertEquals(20.79, currentPosition.x, 0.01);
+        assertEquals(31.53, currentPosition.y, 0.01);
+
+        command.setDirection(new XYPair(0, 1));
+        command.initialize();
+        command.execute();
+
+        setArmAngles(arm.getTargetValue().x, arm.getTargetValue().y);
+        maintainer.execute();
+        timer.advanceTimeInSecondsBy(10);
+        maintainer.execute();
+
+        assertTrue(arm.isMaintainerAtGoal());
+        command.end(false);
+
+        assertEquals(103.27, arm.lowerArm.getArmPositionInDegrees(), 0.01);
+        assertEquals(56.74, arm.upperArm.getArmPositionInDegrees(), 0.01);
+    }
+
+    @Test
+    public void testMoveArmWithCommandBackwards() {
+        setArmAngles(86, -88);
+        XYPair currentPosition = arm.getCurrentXZCoordinates();
+        assertEquals(-29.87, currentPosition.x, 0.01);
+        assertEquals(45.54, currentPosition.y, 0.01);
+
+        command.setDirection(new XYPair(0, 1));
+        command.initialize();
+        command.execute();
+
+        setArmAngles(arm.getTargetValue().x, arm.getTargetValue().y);
+        maintainer.execute();
+        timer.advanceTimeInSecondsBy(10);
+        maintainer.execute();
+
+        assertTrue(arm.isMaintainerAtGoal());
+        command.end(false);
+
+        assertEquals(86.03, arm.lowerArm.getArmPositionInDegrees(), 0.01);
+        assertEquals(-88.89, arm.upperArm.getArmPositionInDegrees(), 0.01);
+    }
+
+    private void setArmAngles(double lowerArmAngle, double upperArmAngle) {
+        ((MockDutyCycleEncoder)arm.lowerArm.absoluteEncoder).setRawPosition(lowerArmAngle/360.0);
+        ((MockDutyCycleEncoder)arm.upperArm.absoluteEncoder).setRawPosition(upperArmAngle/360.0);
+    }
+}


### PR DESCRIPTION
Adds a command to move the arm end-effector in X-Z space

This adds a third controller for experimental buttons. Each of the four D-pad buttons are mapped to moving the claw in one direction.