### PR TITLE
Fix for manual balance mode

### DIFF
--- a/src/main/java/competition/subsystems/drive/commands/ManualBalanceModeCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/ManualBalanceModeCommand.java
@@ -12,14 +12,23 @@ public class ManualBalanceModeCommand extends BaseCommand {
     @Inject
     public ManualBalanceModeCommand(DriveSubsystem drive) {
         this.drive = drive;
-        addRequirements(drive);
     }
 
     @Override
-    public void initialize() { log.info("Initializing"); }
+    public void initialize() {
+        boolean newMode = !drive.isManualBalanceModeActive();
+        log.info("Manual balance mode: " + (newMode ? "enabled" : "disabled"));
+        drive.setManualBalanceMode(newMode);
+    }
 
     @Override
     public void execute() {
-        drive.setManualBalanceMode(!drive.isManualBalanceModeActive());
+        // do nothing
+    }
+
+    @Override
+    public boolean isFinished() {
+        super.isFinished();
+        return true;
     }
 }

--- a/src/test/java/competition/subsystems/drive/swerve/commands/ManualBalanceModeCommandTest.java
+++ b/src/test/java/competition/subsystems/drive/swerve/commands/ManualBalanceModeCommandTest.java
@@ -1,0 +1,29 @@
+package competition.subsystems.drive.swerve.commands;
+
+import competition.BaseCompetitionTest;
+import competition.subsystems.drive.DriveSubsystem;
+import competition.subsystems.drive.commands.ManualBalanceModeCommand;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ManualBalanceModeCommandTest extends BaseCompetitionTest {
+
+    @Test
+    public void testToggle() {
+        DriveSubsystem drive = (DriveSubsystem) getInjectorComponent().driveSubsystem();
+        ManualBalanceModeCommand command = new ManualBalanceModeCommand(drive);
+
+        assertFalse(drive.isManualBalanceModeActive());
+
+        command.initialize();
+
+        assertTrue(drive.isManualBalanceModeActive());
+
+        command.initialize();
+
+        assertFalse(drive.isManualBalanceModeActive());
+    }
+
+}


### PR DESCRIPTION
Toggle should happen in initialize, not execute. We don't need to grab drive subsystem.

Also made logging more helpful for debugging.