### PR TITLE
Ability for a SwerveSimpleTrajectoryCommannd to be finished when near target

### DIFF
--- a/src/main/java/competition/auto_programs/ParameterizedAutonomousProgram.java
+++ b/src/main/java/competition/auto_programs/ParameterizedAutonomousProgram.java
@@ -213,6 +213,7 @@ public class ParameterizedAutonomousProgram extends SequentialCommandGroup {
         driveToPrepareBalance.setKeyPointsProvider(oracle::getTrajectoryForPrepareToBalance);
         driveToPrepareBalance.setEnableConstantVelocity(true);
         driveToPrepareBalance.setConstantVelocity(defaultVelocity);
+        driveToPrepareBalance.setStopWhenFinished(false);
 
         var driveToActualBalance = swerveSimpleTrajectoryCommandProvider.get();
         driveToActualBalance.setMaxPower(0.75);

--- a/src/main/java/competition/subsystems/drive/commands/SwerveSimpleTrajectoryCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/SwerveSimpleTrajectoryCommand.java
@@ -165,6 +165,10 @@ public class SwerveSimpleTrajectoryCommand extends BaseCommand {
     public void execute() {
         var goalVector = getGoalVector();
 
+        // Now that we have a chase point, we can drive to it. The rest of the logic is
+        // from our proven SwerveToPointCommand. Eventually, the common components should be
+        // refactored and should also move towards WPI objects (e.g. Pose2d rather than FieldPose).
+
         // PID on the magnitude of the goal. Kind of similar to rotation,
         // our goal is "zero error".
         double magnitudeGoal = goalVector.getMagnitude();


### PR DESCRIPTION
The idea is to use this for the auto command that goes 'near' the entrance to the charge station. We don't need to be very accurate with reaching this position so it's enough if the robot is vaguely there.

Added a new `stopWhenFinished` variable to SwerveSimpleTrajectoryCommannd. The default is true (current behavior) and if false it's willing to call itself finished much more permissively if it's just vaguely 'near' (6 inches) the target and it doesn't need to have come to a stop or let time settle.