### PR TITLE
Add current limit to steering motors

### DIFF
--- a/src/main/java/competition/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/competition/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -92,13 +92,13 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
                 canCoderUnavailable = true;
             }
         }
-        setupStatusFrames();
+        setupDevices();
     }
 
     /**
-     * Set up status frame intervals to reduce unnecessary CAN activity.
+     * Set up device limits and set status frame intervals to reduce unnecessary CAN activity.
      */
-    private void setupStatusFrames() {
+    private void setupDevices() {
         if (this.contract.isDriveReady()) {
             // We need to re-set frame intervals after a device reset.
             if (this.motorController.getStickyFault(FaultID.kHasReset) && this.motorController.getLastError() != REVLibError.kHALError) {
@@ -114,6 +114,8 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
                 
                 this.motorController.clearFaults();
             }
+
+            this.motorController.setSmartCurrentLimit(40);
         }
 
         if (this.contract.areCanCodersReady() && this.encoder.hasResetOccurred()) {
@@ -354,7 +356,7 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
             //absoluteEncoderPosition.set(getAbsoluteEncoderPositionInDegrees());
         }
         if (contract.isDriveReady()) {
-            setupStatusFrames();
+            setupDevices();
             //motorEncoderPosition.set(getMotorControllerEncoderPosiitonInDegrees());
         }
 

--- a/src/main/java/competition/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/competition/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -80,6 +80,7 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
         if (electricalContract.isDriveReady()) {
             this.motorController = sparkMaxFactory.create(electricalContract.getSteeringNeo(swerveInstance), this.getPrefix(), "SteeringNeo");
             setMotorControllerPositionPidParameters();
+            this.motorController.setSmartCurrentLimit(40);
             this.motorController.setIdleMode(CANSparkMax.IdleMode.kBrake);
         }
         if (electricalContract.areCanCodersReady()) {
@@ -92,13 +93,13 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
                 canCoderUnavailable = true;
             }
         }
-        setupDevices();
+        setupStatusFrames();
     }
 
     /**
-     * Set up device limits and set status frame intervals to reduce unnecessary CAN activity.
+     * Set up status frame intervals to reduce unnecessary CAN activity.
      */
-    private void setupDevices() {
+    private void setupStatusFrames() {
         if (this.contract.isDriveReady()) {
             // We need to re-set frame intervals after a device reset.
             if (this.motorController.getStickyFault(FaultID.kHasReset) && this.motorController.getLastError() != REVLibError.kHALError) {
@@ -114,8 +115,6 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
                 
                 this.motorController.clearFaults();
             }
-
-            this.motorController.setSmartCurrentLimit(40);
         }
 
         if (this.contract.areCanCodersReady() && this.encoder.hasResetOccurred()) {
@@ -356,7 +355,7 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
             //absoluteEncoderPosition.set(getAbsoluteEncoderPositionInDegrees());
         }
         if (contract.isDriveReady()) {
-            setupDevices();
+            setupStatusFrames();
             //motorEncoderPosition.set(getMotorControllerEncoderPosiitonInDegrees());
         }
 

--- a/src/main/java/competition/subsystems/drive/swerve/SwerveSteeringSubsystem.java
+++ b/src/main/java/competition/subsystems/drive/swerve/SwerveSteeringSubsystem.java
@@ -80,6 +80,7 @@ public class SwerveSteeringSubsystem extends BaseSetpointSubsystem<Double> {
         if (electricalContract.isDriveReady()) {
             this.motorController = sparkMaxFactory.create(electricalContract.getSteeringNeo(swerveInstance), this.getPrefix(), "SteeringNeo");
             setMotorControllerPositionPidParameters();
+            // Current limit configured based on the expected current values we see when driving. Typical steering current is ~35A.
             this.motorController.setSmartCurrentLimit(40);
             this.motorController.setIdleMode(CANSparkMax.IdleMode.kBrake);
         }


### PR DESCRIPTION
Logs show one of the steering motors drawing ~80-100A during weekend practice time, as if steering motor was free spinning (loctite broken or gears unmeshed).

Set the current limit to 5A greater than was seen on the other modules.